### PR TITLE
(piqi-rpc) Fix for modifying wrq

### DIFF
--- a/piqi-rpc/src/piqi_rpc_webmachine_resource.erl
+++ b/piqi-rpc/src/piqi_rpc_webmachine_resource.erl
@@ -313,7 +313,7 @@ rpc(ReqData, Context, InputFormat) ->
 
     % allow the server implementation to modify the Webmachine response
     % This allows the implementing module to set response headers such as cookies
-    ReqDataResponse = erlang:get(wrq, ReqData),
+    ReqDataResponse = erlang:get(wrq),
 
     case RpcResponse of
         ok ->


### PR DESCRIPTION
Fix critical mistake in getting wrq from process dictionary after user-code returns. 
