### PR TITLE
Add support for travis-ci service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: erlang
+script: "./travis-ci"
+before_install:
+    - sudo apt-get install ocaml-nox camlp4-extra libfindlib-ocaml-dev
+    - sudo apt-get install libprotoc-dev protobuf-compiler
+otp_release:
+   - R16B
+   - R15B03
+   - R15B02
+   - R15B01
+   - R15B
+   - R14B04
+   - R14B03
+   - R14B02

--- a/travis-ci
+++ b/travis-ci
@@ -1,0 +1,11 @@
+#!/bin/sh -xe
+
+export OCAMLPATH=
+./configure --prefix=/usr
+make deps
+make
+. ./setenv.sh
+make erlang
+
+make -C tests
+make -C tests erlang


### PR DESCRIPTION
This allows running tests on shared continuous integration testing
service travis-ci.org. Currently it does:
1. compile
2. run tests (incl. ones that require protobuffers)
3. run erlang tests

Tests are executed on Erlang platforms R14B02-R16B.

Here, it works: https://travis-ci.org/Motiejus/piqi

Steps which should be done before merging this pull request:
1. log in to travis-ci.org with your github account
2. find "piqi" in "my repositories"
3. click "on"

Then merge. Once the pull request is merged, github bot will notify travis-ci that something has been updated, and piqi will be tested.

When piqi-erlang and piqi-rpc are completely decoupled from this repository, this will obviously change.
