### PR TITLE
Fix test.cpp compile error

### DIFF
--- a/tests/cpp/test.cpp
+++ b/tests/cpp/test.cpp
@@ -2,6 +2,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #include <iostream>
 #include <google/protobuf/text_format.h>


### PR DESCRIPTION
On gcc 4.7 this error happens:

```
test.cpp: In function 'int main(int, char**)':
test.cpp:28:13: error: 'close' was not declared in this scope
```

Ubuntu 12.10 onwards has gcc >=4.7 and thus cannot compile this file.
