### PR TITLE
don't forget some people like to link with cma's

### DIFF
--- a/piqilib/Makefile
+++ b/piqilib/Makefile
@@ -81,7 +81,7 @@ SOURCES = \
 PRE_TARGETS = piqi_version.ml META
 
 
-all: ncl
+all: ncl bcl
 
 
 debug: dcl top


### PR DESCRIPTION
Hi,

I noticed that when I tried to compile some dependencies with piqi, that I couldn't throw in cma's... I've tested it, and when compiling from the repo, it also requires base64, possibly some changes in github that are not in opam??
