### PR TITLE
Commit changes in order that, when piqi is built the ocaml interpreter can load it at runtime

### DIFF
--- a/piqilib/Makefile
+++ b/piqilib/Makefile
@@ -79,9 +79,14 @@ SOURCES = \
 
 
 PRE_TARGETS = piqi_version.ml META
+libpiqilib_stubs:
+	ocamlfind ocamlmklib -o piqilib_stubs piqi_c_impl.o
+custom_piqilib_cma:
+	ocamlfind ocamlc -a -cclib -lpiqilib_stubs -dllib -lpiqilib_stubs -o piqilib.cma piqi_version.cmo piqi_piqirun.cmo piqi_piqi.cmo piqloc.cmo piqi_util.cmo piq_ast.cmo piqi_impl_piqi.cmo piqi_boot.cmo piqi_c.cmo piqi_config.cmo piqi_iolist.cmo piqi_name.cmo piqi_common.cmo piqi_file.cmo piqi_command.cmo piqi_protobuf.cmo piqi_db.cmo piq_lexer.cmo piq_parser.cmo piq_gen.cmo piqi_objstore.cmo piqobj.cmo piqobj_common.cmo piqobj_to_protobuf.cmo piqobj_of_protobuf.cmo piqobj_to_piq.cmo piqobj_of_piq.cmo piq.cmo piqi.cmo piqi_pp.cmo piqi_json_parser.cmo piqi_json_gen.cmo piqi_json.cmo piqi_base64.cmo piqobj_to_json.cmo piqobj_of_json.cmo piqi_xml.cmo piqobj_to_xml.cmo piqobj_of_xml.cmo piqi_convert.cmo piqi_compile.cmo piqi_light.cmo piqi_getopt.cmo
 
+POST_TARGETS: libpiqilib_stubs custom_piqilib_cma
 
-all: ncl
+all: ncl bcl POST_TARGETS
 
 
 debug: dcl top
@@ -89,8 +94,9 @@ debug: dcl top
 
 # NOTE: when installing, uninstall first to avoid "already installed" error
 # also, make sure we have the byte-code version of the library built as well
-install: uninstall libinstall
-
+install: uninstall libinstall POST_TARGETS
+	cp dllpiqilib_stubs.so $(shell opam config var lib)/stublibs
+	cp piqilib.cma $(shell opam config var lib)/piqilib
 
 uninstall: libuninstall
 


### PR DESCRIPTION
An rather irksome bug has been plagueing me for the past 3 days. It was impossible to load the piqi library at runtime, and after a lengthy process to get it to work I found out what it was.

I couldn't well specify to OCamlMakefile that -custom should not be used and still get the requisite dependencies of the .so file out cleanly. It has an option for compiling a toplevel for just this library, but that's not a sufficient solution. Oasis is the appropriate tool for building a custom toplevel much more cleanly and what I'm familiar with, but I'm not in the business of telling people what to do. So, what I did was put a small hot fix in the makefile so it would be done correctly. It works, and I tested it as best I could.