### PR TITLE
Switch to using <stdint.h> types

### DIFF
--- a/piqilib/piqi_c_impl.c
+++ b/piqilib/piqi_c_impl.c
@@ -78,7 +78,7 @@ value camlidl_piqi_c_piqi_strtoull(
 	value _v_str)
 {
   char *str; /*in*/
-  int64 _res;
+  int64_t _res;
   value _vres;
 
   str = String_val(_v_str);


### PR DESCRIPTION
The fixed-width integer types in <caml/mlvalues.h> have been removed in
ocaml-4.03.0. Their users are expected to migrate to the <stdint.h>
types (see
https://github.com/ocaml/ocaml/commit/b868c05ec91a7ee193010a421de768a3b1a80952).