### PR TITLE
spelling fixes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -88,7 +88,7 @@ Piq language:
 
 Miscellaneous:
 
-  - Compatiblity with OCaml 4.02.0
+  - Compatibility with OCaml 4.02.0
   - Various code layout and build improvements
 
 
@@ -651,7 +651,7 @@ piqic:
 
   - (ocaml, erlang) Normalize Piqi identifiers by default, i.e. convert
     "CamlCase" identifiers to "caml-case".
-  - (ocaml, erlang) Don't generate codecs and types for unused defintions from
+  - (ocaml, erlang) Don't generate codecs and types for unused definitions from
     the boot module.
 
 piqirun-ocaml:

--- a/doc/piqi.1
+++ b/doc/piqi.1
@@ -328,7 +328,7 @@ Usage:
 \f[C]piqi\ json\-pp\ [options]\ [<.json\ file>]\ [output\ file]\f[]
 .PP
 Pretty\-prints JSON files.
-Input file may contain several properly formated JSON objects
+Input file may contain several properly formatted JSON objects
 represented as UTF\-8 text as defined by RFC
 4627 (http://www.ietf.org/rfc/rfc4627.txt).
 .PP

--- a/doc/tools.md
+++ b/doc/tools.md
@@ -256,7 +256,7 @@ Options:
 
 Usage: `piqi json-pp [options] [<.json file>] [output file]`
 
-Pretty-prints JSON files. Input file may contain several properly formated JSON
+Pretty-prints JSON files. Input file may contain several properly formatted JSON
 objects represented as UTF-8 text as defined by [RFC
 4627](http://www.ietf.org/rfc/rfc4627.txt).
 

--- a/examples/function.piq
+++ b/examples/function.piq
@@ -1,4 +1,4 @@
-% input/ouput/error of functions defined in function.piqi
+% input/output/error of functions defined in function.piqi
 
 :function/bar-input [ 10 ]
 :function/bar-output 1

--- a/examples/test_piq
+++ b/examples/test_piq
@@ -20,7 +20,7 @@ $PIQI check $f.piq
 
 
 # convert to "piq" encoding and print to stdout. "piq" encoding is used as
-# default ouput encoding. Input encoding is determined by file's extension
+# default output encoding. Input encoding is determined by file's extension
 # unless specified explicitly.
 $PIQI convert $f.piq
 

--- a/piqi/piqi.piqi
+++ b/piqi/piqi.piqi
@@ -15,7 +15,7 @@
 
 % The current Piqi self-specification
 %
-% This file contains defintion of the Piqi self-specification
+% This file contains definition of the Piqi self-specification
 
 
 % aliases for built-in types; these definitions are automatically included in

--- a/piqilib/piq_parser.ml
+++ b/piqilib/piq_parser.ml
@@ -314,7 +314,7 @@ let retry_parse_uint s =
 let parse_uint s =
   (* NOTE:
    * OCaml doesn't support large unsingned decimal integer literals. For
-   * intance, this call failes with exception (Failure "int_of_string"):
+   * instance, this call failes with exception (Failure "int_of_string"):
    *
    *      Int64.of_string (Printf.sprintf "%Lu" 0xffff_ffff_ffff_ffffL)
    *
@@ -474,7 +474,7 @@ let read_next ?(expand_abbr=true) (fname, lexstream) =
            * and to be consisten with "identity" forms like (.foo) *)
           ()
     );
-    (* contruct a resulting form from name and args *)
+    (* construct a resulting form from name and args *)
     let pair = (name, args) in
     let res = `form pair in
     Piqloc.addloc startloc pair;

--- a/piqilib/piqi.ml
+++ b/piqilib/piqi.ml
@@ -779,7 +779,7 @@ let mlobj_to_piqobj piqtype wire_generator mlobj =
   let binobj = Piqirun.gen_binobj wire_generator mlobj in
   debug_loc "mlobj_to_piqobj(1.5)";
 
-  (* dont' resolve defaults when reading wire *)
+  (* don't' resolve defaults when reading wire *)
   let piqobj =
     U.with_bool C.is_inside_parse_piqi true
     (fun () ->
@@ -975,7 +975,7 @@ let apply_extensions obj obj_def obj_parse_f obj_gen_f extension_entries custom_
         ) extension_asts
       in
       (*
-      List.iter (Printf.eprintf "extesion label: %s\n") extension_labels;
+      List.iter (Printf.eprintf "extension label: %s\n") extension_labels;
       *)
       let is_overridden = function
           | `named x ->
@@ -1194,7 +1194,7 @@ let apply_defs_extensions defs extensions custom_fields =
   list_of_idtable idtable defs C.typedef_name
 
 
-(* partition extensions into typedef extesions, function extensions and import
+(* partition extensions into typedef extensions, function extensions and import
  * extensions *)
 let partition_extensions extensions =
   let open Extend in
@@ -1230,7 +1230,7 @@ let get_imported_defs imports =
 
 
 let make_param_name func param_name =
-  (* construct the type name as a concatentation of the function name and
+  (* construct the type name as a concatenation of the function name and
    * -input|output|error *)
   let func_name = func.T.Func.name in
   let type_name = func_name ^ "-" ^ param_name in
@@ -1314,7 +1314,7 @@ let resolve_param func param_name param =
 
 (* return func, [(def, (def_name, set_f))], where
  *
- * [def] is a definition derived from the function's input/output/erorr
+ * [def] is a definition derived from the function's input/output/error
  * parameter
  *
  * [def_name] is the definition's name
@@ -1459,7 +1459,7 @@ let find_piqi_file from_piqi modname =
     in
     (modname, fname)
   else  (* regular module loaded from a .piqi file *)
-    (* add the referee dirname as a .piqi search path in front of the curent
+    (* add the referee dirname as a .piqi search path in front of the current
      * working directory, which is always the first element of the search path
      * list *)
     let dir = Filename.dirname (some_of from_piqi.P.file) in
@@ -1653,7 +1653,7 @@ let rec process_piqi ?modname ?(include_path=[]) ?(fname="") ?(ast: piq_ast opti
   let idtable = Idtable.empty in
   let idtable = add_imported_typedefs idtable imported_defs in
 
-  (* add built-in type defintions to the idtable *)
+  (* add built-in type definitions to the idtable *)
   let idtable =
     if not !Config.flag_no_builtin_types && not !is_boot_mode && not (C.is_self_spec piqi)
     then add_typedefs idtable !C.builtin_typedefs
@@ -1707,7 +1707,7 @@ let rec process_piqi ?modname ?(include_path=[]) ?(fname="") ?(ast: piq_ast opti
         apply_defs_extensions defs defs_extensions custom_fields
     )
   in
-  (* preserve the original defintions by making a copy *)
+  (* preserve the original definitions by making a copy *)
   let resolved_defs = copy_defs extended_defs in
 
   (* set resolved_func.resolved_input/output/error fields to their correspondent
@@ -1738,7 +1738,7 @@ let rec process_piqi ?modname ?(include_path=[]) ?(fname="") ?(ast: piq_ast opti
    * and option codes instead of auto-enumerated ones
    *
    * NOTE: code assignment is needed only for .piqi, Piqi specifications encoded
-   * in other formats must already include explicitly speficied (and correct!)
+   * in other formats must already include explicitly specified (and correct!)
    * wire codes.
    *
    * NOTE: this step must be performed before resolving defaults -- this is
@@ -1747,7 +1747,7 @@ let rec process_piqi ?modname ?(include_path=[]) ?(fname="") ?(ast: piq_ast opti
   if ast <> None && C.is_self_spec piqi
   then Piqi_protobuf.add_hashcodes resolved_defs;
 
-  (* check defs, resolve defintion names to types, assign codes, resolve default
+  (* check defs, resolve definition names to types, assign codes, resolve default
    * fields *)
   let idtable = resolve_defs idtable resolved_defs ~piqi in
 
@@ -1952,7 +1952,7 @@ let find_embedded_piqtype name =
 
 
 (*
- * booting code; preparing the initial statically defined piqi defintions
+ * booting code; preparing the initial statically defined piqi definitions
  *)
 let boot () =
   trace "boot(0)\n";
@@ -2133,7 +2133,7 @@ let expand_piqi ~extensions ~functions piqi =
         res_piqi with
         (* add embedded definitions from function to the list of top-level defs *)
         typedef = res_piqi.typedef @ func_typedefs;
-        (* remove embedded defintions from function parameters *)
+        (* remove embedded definitions from function parameters *)
         func = List.map expand_function res_piqi.func;
       }
   in res_piqi
@@ -2211,7 +2211,7 @@ let piqi_to_piqobj
 
   (* include all automatically assigned hash-based codes for fiels and options;
    * this is a protection against changing the hashing algorithm: even if new
-   * piqi versions use a different hashing algorith, previous self-definitions
+   * piqi versions use a different hashing algorithm, previous self-definitions
    * will be still readable *)
   if C.is_self_spec piqi
   then Piqi_protobuf.add_hashcodes piqi_spec.P.typedef

--- a/piqilib/piqi_command.ml
+++ b/piqilib/piqi_command.ml
@@ -119,7 +119,7 @@ let default_anon_fun s =
         (* the first positional argument is input file *)
         ifile := s
     | 2 ->
-        (* the second positional argument is output file unless overriden by -o
+        (* the second positional argument is output file unless overridden by -o
          * option *)
         if !ofile = ""
         then ofile := s

--- a/piqilib/piqi_common.ml
+++ b/piqilib/piqi_common.ml
@@ -165,7 +165,7 @@ let full_piqi_typename x =
           parent_name ^ "/" ^ name
     | _ -> (* built-in type *)
         (* XXX: normally built-in types should be used at the time when this
-         * funciton is used *)
+         * function is used *)
         name
 
 

--- a/piqilib/piqi_convert.ml
+++ b/piqilib/piqi_convert.ml
@@ -53,7 +53,7 @@ let pre_process_piqi ~fname ?ast piqi =
   piqi.P.is_embedded <- Some true;
 
   (* can't process it right away, because not all dependencies could be loaded
-   * already; this is expecially ciritical in case of mutually-recursive
+   * already; this is especially ciritical in case of mutually-recursive
    * includes; just do bare minimum so that we could add to Piqi_db and process
    * it later *)
   let piqi = Piqi.pre_process_piqi piqi ~fname ?ast in
@@ -61,7 +61,7 @@ let pre_process_piqi ~fname ?ast piqi =
   (* so that we could find it by name later *)
   Piqi_db.add_piqi piqi;
 
-  (* preserve location information so that exising location info for Piqi
+  (* preserve location information so that existing location info for Piqi
    * modules won't be discarded by subsequent Piqloc.reset() calls *)
   Piqloc.preserve ();
 

--- a/piqilib/piqi_file.ml
+++ b/piqilib/piqi_file.ml
@@ -71,7 +71,7 @@ let make_os_path name =
     | _ -> name
 
 
-(* find piqi file in search paths given its (relative) splitted name *)
+(* find piqi file in search paths given its (relative) split name *)
 let find_piqi_file ?(extra_paths=[]) modname =
   let dir_name, base_name = Piqi_name.split_name modname in
   let dir_name =

--- a/piqilib/piqi_getopt.ml
+++ b/piqilib/piqi_getopt.ml
@@ -351,7 +351,7 @@ let argv_start_index = ref 0
 
 (* find the position of the first argument after "--" *)
 let rest_fun arg =
-  if !argv_start_index = 0 (* first argument after first occurence of "--" *)
+  if !argv_start_index = 0 (* first argument after first occurrence of "--" *)
   then argv_start_index := !Arg.current + 1
   else ()
 

--- a/piqilib/piqi_name.ml
+++ b/piqilib/piqi_name.ml
@@ -130,7 +130,7 @@ let is_normal_name s =
   aux 0
 
 
-(* convert an arbitary valid name to lowercase name which words are separated by
+(* convert an arbitrary valid name to lowercase name which words are separated by
  * dashes; for example "CamelCase" will become "camel-case"; already lowercased
  * names will remain intact *)
 let normalize_name s =

--- a/piqilib/piqi_piqirun.ml
+++ b/piqilib/piqi_piqirun.ml
@@ -310,7 +310,7 @@ let try_parse_varint buf =
 
 
 (* TODO, XXX: check signed overflow *)
-(* TODO: optimize for little-endian achitecture *)
+(* TODO: optimize for little-endian architecture *)
 let parse_fixed32 buf =
   try
     let res = ref 0l in
@@ -798,7 +798,7 @@ let parse_default binobj =
   buf
 
 
-(* XXX, NOTE: using default with requried or optional-default fields *)
+(* XXX, NOTE: using default with required or optional-default fields *)
 let parse_required_field code parse_value ?default l =
   let res, rem = find_field code l in
   match res with

--- a/piqilib/piqloc.ml
+++ b/piqilib/piqloc.ml
@@ -147,7 +147,7 @@ let reset () =
 
 
 (* Preserve location information by copying the contents of db to preserved_db
- * so that exising location info won't be discarded by subsequent reset() calls.
+ * so that existing location info won't be discarded by subsequent reset() calls.
  *)
 let preserve () =
   preserved_db := !db @ !preserved_db;

--- a/piqilib/piqobj_of_json.ml
+++ b/piqilib/piqobj_of_json.ml
@@ -242,7 +242,7 @@ and parse_optional_field name field_type default l =
 and parse_repeated_field name field_type l =
   let res, rem = find_fields name l in
   match res with
-    | [] -> [], rem (* XXX: allowing repeated field to be acutally missing *)
+    | [] -> [], rem (* XXX: allowing repeated field to be actually missing *)
     | [`List l] ->
         let res = List.map (parse_obj field_type) l in
         res, rem

--- a/piqilib/piqobj_of_piq.ml
+++ b/piqilib/piqobj_of_piq.ml
@@ -75,7 +75,7 @@ let add_unknown_field x =
 
 let get_unknown_fields () =
   let res = List.rev !unknown_fields in
-  (* reset unkown field list state *)
+  (* reset unknown field list state *)
   unknown_fields := [];
   res
 
@@ -578,7 +578,7 @@ and parse_repeated_field f name field_type l =
   let res, rem = find_fields name f.T.Field.piq_alias field_type l in
   match res with
     | [] -> 
-        (* XXX: ignore errors occuring when unknown element is present in the
+        (* XXX: ignore errors occurring when unknown element is present in the
          * list allowing other fields to find their members among the list of
          * elements *)
         let accu, rem =

--- a/piqilib/piqobj_of_xml.ml
+++ b/piqilib/piqobj_of_xml.ml
@@ -267,7 +267,7 @@ and parse_optional_field name field_type default l =
 and parse_repeated_field name field_type l =
   let res, rem = find_fields name l in
   match res with
-    | [] -> [], rem (* allowing repeated field to be acutally missing *)
+    | [] -> [], rem (* allowing repeated field to be actually missing *)
     | l ->
         let res = List.map (parse_obj field_type) l in
         res, rem

--- a/src/compile.ml
+++ b/src/compile.ml
@@ -102,7 +102,7 @@ let compile self_spec piqi och =
         List.iter write_piq piqobj_list
     | "piqi" ->
         (* NOTE: with output_format = "piqi" we can output only one modele --
-         * the one that's beeing compiled; it comes last in the list *)
+         * the one that's being compiled; it comes last in the list *)
         let piqobj = List.hd (List.rev piqobj_list) in
         let ast = Piqi_convert.gen_piq (Piqi_convert.Piqobj piqobj) in
         Piqi_pp.prettyprint_piqi_ast och ast

--- a/src/of_proto.ml
+++ b/src/of_proto.ml
@@ -680,7 +680,7 @@ let proto_to_piqi ifile =
   (* convert .proto file to wire format using protoc --descriptor_set_out= *)
   proto_to_wire ifile wirefile;
 
-  (* read .proto defintion from wire file *)
+  (* read .proto definition from wire file *)
   let proto_set = read_proto_wire wirefile in
 
   (* convert .proto to .piqi string *)

--- a/src/piqi_http.ml
+++ b/src/piqi_http.ml
@@ -323,7 +323,7 @@ let make_curl_command
       | Some x -> "--data-binary @-"
   in
   (*
-    -i stands for output reponse http header in addition to payload data
+    -i stands for output response http header in addition to payload data
     -s stands for silent
   *)
   String.concat " " [

--- a/src/to_proto.ml
+++ b/src/to_proto.ml
@@ -599,7 +599,7 @@ let protoname_defs (defs:T.typedef list) =
 
 
 (* generate warning when deprecated fiels are used and provde some backwards
- * compatibiliy *)
+ * compatibility *)
 let check_transform_piqi piqi =
   (* handle deprecated .proto-package *)
   (match piqi.P.proto_package with


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.