### PR TITLE
Add 4.09 OCaml in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ matrix:
         # in addition, test opam package build (PACKAGE="piqilib")
     - os: linux
       env: OCAML_VERSION=4.08 PACKAGE="piqilib"
+    - os: linux
+      env: OCAML_VERSION=4.09 PACKAGE="piqilib"
     # testing only basic install on osx with latest homebrew formulas
     - os: osx
       env: OCAML_VERSION=homebrew


### PR DESCRIPTION
With [OCaml 4.09 released](https://discuss.ocaml.org/t/ocaml-4-09-0-released/4384), which is largely a bugfix release, it makes sense to check it too.