### PR TITLE
adds commands to piqi frontend

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,32 @@
 (executable
  (name run)
  (public_name piqi)
- (libraries unix piqilib))
+ (libraries commands unix piqilib)
+ (modules run)
+ (flags -linkall))
+
+(library
+ (name commands)
+ (wrapped false)
+ (libraries unix piqilib)
+ (preprocess (pps sedlex.ppx))
+ (modules
+   call
+   cc
+   check
+   compile
+   convert
+   descriptor_piqi
+   expand
+   getopt
+   json_pp
+   light
+   main
+   of_proto
+   piqi_http
+   piqi_rpc
+   piqi_rpc_piqi
+   piqi_tools_piqi
+   pp
+   server
+   to_proto))


### PR DESCRIPTION
When testing installation using opam, I noticed that `piqi` command doesn't list any commands. Indeed, the `run` module doesn't register any and the commands are provided by other modules that are not referenced in `run.ml`. This commit fixes the issue and packs the commands implementations into the private `commands` library, which is linked with `-linkall` to the main executable.

I made the library private by default, i.e., no cmi are installed and modules are not accessible outside of the `src` folder, but we can easily make it public, if necessary.