### PR TITLE
adds CI with the build task

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: build
+on:
+  - pull_request
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+        ocaml-version:
+          - 4.14.0
+          - 4.03.0
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Use OCaml ${{ matrix.ocaml-version }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-version }}
+
+      - run: opam pin add piqilib .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,9 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
-          - windows-latest
         ocaml-version:
-          - 4.14.0
-          - 4.03.0
+          - 4.13.x
+          - 4.03.x
 
     runs-on: ${{ matrix.os }}
 

--- a/dune
+++ b/dune
@@ -3,3 +3,5 @@
  (release (flags (:standard
                    -warn-error -A
                    -w -6-9-27-32..34-37-50-58))))
+
+(data_only_dirs tests)

--- a/opam
+++ b/opam
@@ -6,10 +6,10 @@ maintainer: "Anton Lavrik <alavrik@piqi.org>"
 homepage: "http://piqi.org"
 bug-reports: "https://github.com/alavrik/piqi/issues"
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "4.14.0"}
   "ocamlfind" {build}
   "easy-format"
-  "sedlex" {< "3.0.0"}
+  "sedlex" {< "3.0"}
   "xmlm"
   "base64" {>="3.1.0"}
 ]

--- a/opam
+++ b/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml" {>= "4.03"}
   "ocamlfind" {build}
   "easy-format"
-  "sedlex"
+  "sedlex" {< "3.0.0"}
   "xmlm"
   "base64" {>="3.1.0"}
 ]


### PR DESCRIPTION
Let's start with a simple built task and we can later add some tests. So far this test revealed that piqi doesn't work with 4.14 because they have removed the Stream library. And windows builds fail because of the symbolic links. 